### PR TITLE
fix: gracile & gracile-watch not working on linux

### DIFF
--- a/packages/gracile/src/bin/gracile-watch.ts
+++ b/packages/gracile/src/bin/gracile-watch.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node ./node_modules/@gracile/gracile/dist/bin/helpers/tsx-cli.js --no-warnings=ExperimentalWarning -C production --watch
+#!/usr/bin/env -S node ./node_modules/@gracile/gracile/dist/bin/helpers/tsx-cli.js --no-warnings=ExperimentalWarning -C production --watch
 
 import './helpers/version.js';
 

--- a/packages/gracile/src/bin/gracile.ts
+++ b/packages/gracile/src/bin/gracile.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node ./node_modules/@gracile/gracile/dist/bin/helpers/tsx-cli.js --no-warnings=ExperimentalWarning -C production
+#!/usr/bin/env -S node ./node_modules/@gracile/gracile/dist/bin/helpers/tsx-cli.js --no-warnings=ExperimentalWarning -C production
 
 import './helpers/version.js';
 


### PR DESCRIPTION
running the cli on linux system currenty fails as multiple args cannot be passed like this to env.
Adding `-S` flag to fix.