### PR TITLE
Add support to the existing marked markdown preset for footnotes

### DIFF
--- a/packages/addons/markdown-preset-marked/package.json
+++ b/packages/addons/markdown-preset-marked/package.json
@@ -42,6 +42,7 @@
     "@gracile/markdown": "workspace:^",
     "github-slugger": "^2.0.0",
     "marked": "14.1.3",
+    "marked-footnote": "^1.2.4",
     "marked-gfm-heading-id": "^4.1.0",
     "ultramatter": "^0.0.4"
   },

--- a/packages/addons/markdown-preset-marked/src/renderer.ts
+++ b/packages/addons/markdown-preset-marked/src/renderer.ts
@@ -4,6 +4,7 @@ import { MarkdownRendererBase } from '@gracile/markdown/renderer';
 import { slug as slugger } from 'github-slugger';
 import { marked, type Token } from 'marked';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
+import markedFootnote from 'marked-footnote';
 import * as ultramatter from 'ultramatter';
 
 let collectedHeadings: Heading[] = [];
@@ -24,7 +25,7 @@ export class MarkdownRenderer extends MarkdownRendererBase {
 
 		collectedHeadings = [];
 		collectedExcerpt = '';
-		const html = await marked.parse(content);
+		const html = await marked.use(markedFootnote()).parse(content);
 
 		this.setTableOfContents(buildHierarchy(collectedHeadings));
 		this.setTableOfContentsFlat(collectedHeadings);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 9.13.0
       '@lerna-lite/cli':
         specifier: ^3.10.0
-        version: 3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
+        version: 3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/list':
         specifier: ^3.10.0
         version: 3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)
@@ -235,6 +235,9 @@ importers:
       marked:
         specifier: 14.1.3
         version: 14.1.3
+      marked-footnote:
+        specifier: ^1.2.4
+        version: 1.2.4(marked@14.1.3)
       marked-gfm-heading-id:
         specifier: ^4.1.0
         version: 4.1.0(marked@14.1.3)
@@ -3469,6 +3472,11 @@ packages:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
 
+  marked-footnote@1.2.4:
+    resolution: {integrity: sha512-DB2Kl+wFh6YwZd70qABMY6WUkG1UuyqoNTFoDfGyG79Pz24neYtLBkB+45a7o72V7gkfvbC3CGzIYFobxfMT1Q==}
+    peerDependencies:
+      marked: '>=7.0.0'
+
   marked-gfm-heading-id@4.1.0:
     resolution: {integrity: sha512-xRvV65Fnpq1krNspnyGsBvP0Y6h7/FrJ6U6y4e6zCWffiC1KxFFxFUKVu8ufMHop2xdvpwyWj5jPeA5W5x/6Zw==}
     peerDependencies:
@@ -5365,7 +5373,7 @@ snapshots:
 
   '@kamilkisiela/fast-url-parser@1.1.4': {}
 
-  '@lerna-lite/cli@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)':
+  '@lerna-lite/cli@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)':
     dependencies:
       '@lerna-lite/core': 3.10.0(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/init': 3.10.0(@types/node@22.8.1)(typescript@5.6.3)
@@ -5378,7 +5386,7 @@ snapshots:
     optionalDependencies:
       '@lerna-lite/list': 3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/publish': 3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)
-      '@lerna-lite/version': 3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)
+      '@lerna-lite/version': 3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5439,7 +5447,7 @@ snapshots:
 
   '@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)':
     dependencies:
-      '@lerna-lite/cli': 3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/core': 3.10.0(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/listable': 3.10.0(@types/node@22.8.1)(typescript@5.6.3)
     transitivePeerDependencies:
@@ -5480,10 +5488,10 @@ snapshots:
 
   '@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)':
     dependencies:
-      '@lerna-lite/cli': 3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/core': 3.10.0(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/npmlog': 3.10.0
-      '@lerna-lite/version': 3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)
+      '@lerna-lite/version': 3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.1
       byte-size: 9.0.0
@@ -5516,9 +5524,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3)':
+  '@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)':
     dependencies:
-      '@lerna-lite/cli': 3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0)(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
+      '@lerna-lite/cli': 3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/version@3.10.0(@lerna-lite/list@3.10.0(@lerna-lite/publish@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@lerna-lite/publish@3.10.0(@lerna-lite/list@3.10.0)(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3))(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/core': 3.10.0(@types/node@22.8.1)(typescript@5.6.3)
       '@lerna-lite/npmlog': 3.10.0
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -7062,7 +7070,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.13.0(jiti@2.3.3)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.3.3))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-plugin-import-x@4.3.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -7076,7 +7084,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.3.3)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-plugin-import-x@4.3.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7115,7 +7123,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@2.3.3)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.3.3))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-plugin-import-x@4.3.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))
       hasown: '@nolyfill/hasown@1.0.29'
       is-core-module: '@nolyfill/is-core-module@1.0.39'
       is-glob: 4.0.3
@@ -8034,6 +8042,10 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  marked-footnote@1.2.4(marked@14.1.3):
+    dependencies:
+      marked: 14.1.3
 
   marked-gfm-heading-id@4.1.0(marked@14.1.3):
     dependencies:


### PR DESCRIPTION
it turned out to be trivial to add GFM footnote support with marked-footnote to the existing marked markdown preset.  I suppose this could be optional, but I'm not sure how to add in an option to the preset plugin's config, though if such an option existed, it would be easy to change the way marked is called based on that option.  As it stands, with this patch, it is on all the time.  